### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -18,7 +18,7 @@
     ],
     "sharedGlobals": ["{workspaceRoot}/.github/workflows/ci.yml"]
   },
-  "nxCloudId": "68a766bdb51b57372b7d0b1e",
+  "nxCloudId": "68dec7fb534fed6d9f145bed",
   "plugins": [
     {
       "plugin": "@nx/webpack/plugin",
@@ -28,24 +28,9 @@
         "previewTargetName": "preview"
       }
     },
-    {
-      "plugin": "@nx/eslint/plugin",
-      "options": {
-        "targetName": "lint"
-      }
-    },
-    {
-      "plugin": "@nx/playwright/plugin",
-      "options": {
-        "targetName": "e2e"
-      }
-    },
-    {
-      "plugin": "@nx/jest/plugin",
-      "options": {
-        "targetName": "test"
-      }
-    },
+    {"plugin": "@nx/eslint/plugin", "options": {"targetName": "lint"}},
+    {"plugin": "@nx/playwright/plugin", "options": {"targetName": "e2e"}},
+    {"plugin": "@nx/jest/plugin", "options": {"targetName": "test"}},
     {
       "plugin": "@nx/storybook/plugin",
       "options": {
@@ -57,13 +42,8 @@
     }
   ],
   "targetDefaults": {
-    "e2e-ci--**/*": {
-      "dependsOn": ["^build"]
-    },
-    "build": {
-      "cache": true,
-      "dependsOn": ["^build"]
-    },
+    "e2e-ci--**/*": {"dependsOn": ["^build"]},
+    "build": {"cache": true, "dependsOn": ["^build"]},
     "@nx/eslint:lint": {
       "cache": true,
       "inputs": [
@@ -74,13 +54,7 @@
       ]
     },
     "@nx/webpack:webpack": {
-      "inputs": [
-        "production",
-        "^production",
-        {
-          "env": "NX_MF_DEV_REMOTES"
-        }
-      ],
+      "inputs": ["production", "^production", {"env": "NX_MF_DEV_REMOTES"}],
       "dependsOn": ["^build"],
       "cache": true
     }
@@ -93,14 +67,8 @@
         "linter": "eslint",
         "bundler": "webpack"
       },
-      "component": {
-        "style": "less"
-      },
-      "library": {
-        "style": "less",
-        "linter": "eslint",
-        "unitTestRunner": "jest"
-      }
+      "component": {"style": "less"},
+      "library": {"style": "less", "linter": "eslint", "unitTestRunner": "jest"}
     }
   }
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://cloud.nx.app/orgs/68dec3138234a5433cf63903/workspaces/68dec7fb534fed6d9f145bed

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.